### PR TITLE
Minor cleanups around TSP naming and order

### DIFF
--- a/qspeakers_en.ts
+++ b/qspeakers_en.ts
@@ -826,7 +826,7 @@
     </message>
     <message>
         <location filename="speakerdialog.ui" line="108"/>
-        <source>Dia (m)</source>
+        <source>Dia cutout (m)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -881,7 +881,7 @@
     </message>
     <message>
         <location filename="speakerdialog.ui" line="271"/>
-        <source>Voice Coil</source>
+        <source>Voice Coil (#)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/qspeakers_fr.ts
+++ b/qspeakers_fr.ts
@@ -828,7 +828,7 @@
     <message>
         <location filename="speakerdialog.ui" line="108"/>
         <source>Dia (m)</source>
-        <translation>Dia (m)</translation>
+        <translation>Diamètre de découpe (m)</translation>
     </message>
     <message>
         <location filename="speakerdialog.ui" line="125"/>
@@ -882,8 +882,8 @@
     </message>
     <message>
         <location filename="speakerdialog.ui" line="271"/>
-        <source>Voice Coil</source>
-        <translation>Nb de voix</translation>
+        <source>Voice Coil (#)</source>
+        <translation>Nb de voix (#)</translation>
     </message>
 </context>
 <context>

--- a/speaker.cpp
+++ b/speaker.cpp
@@ -10,16 +10,16 @@ Speaker::Speaker() :
     re(0.0),
     qts(0.0),
     sd(0.0),
-    xmax(0.0),
     z(0.0),
-    le(0.0),
     qms(0.0),
     qes(0.0),
     spl(0.0),
     pe(0.0),
+    le(0.0),
+    xmax(0.0),
     bl(0.0),
-    dia(0.0),
-    vc(1)
+    vc(1),
+    dia(0.0)
 {
 }
 
@@ -30,16 +30,16 @@ Speaker::Speaker(const Speaker &copy)
     this->re = copy.getRe();
     this->qts = copy.getQts();
     this->sd = copy.getSd();
-    this->xmax = copy.getXmax();
     this->z = copy.getZ();
-    this->dia = copy.getDia();
-    this->bl = copy.getBL();
-    this->le = copy.getLe();
-    this->pe = copy.getPe();
-    this->qes = copy.getQes();
     this->qms = copy.getQms();
+    this->qes = copy.getQes();
     this->spl = copy.getSpl();
+    this->pe = copy.getPe();
+    this->le = copy.getLe();
+    this->xmax = copy.getXmax();
+    this->bl = copy.getBL();
     this->vc = copy.getVc();
+    this->dia = copy.getDia();
 
     this->vendor = copy.getVendor();
     this->model = copy.getModel();
@@ -57,16 +57,16 @@ Speaker &Speaker::operator=(const Speaker &copy)
     this->re = copy.getRe();
     this->qts = copy.getQts();
     this->sd = copy.getSd();
-    this->xmax = copy.getXmax();
     this->z = copy.getZ();
-    this->dia = copy.getDia();
-    this->bl = copy.getBL();
-    this->le = copy.getLe();
-    this->pe = copy.getPe();
-    this->qes = copy.getQes();
     this->qms = copy.getQms();
+    this->qes = copy.getQes();
     this->spl = copy.getSpl();
+    this->pe = copy.getPe();
+    this->le = copy.getLe();
+    this->xmax = copy.getXmax();
+    this->bl = copy.getBL();
     this->vc = copy.getVc();
+    this->dia = copy.getDia();
 
     this->vendor = copy.getVendor();
     this->model = copy.getModel();
@@ -96,15 +96,15 @@ bool Speaker::operator==(const Speaker& r) const
             almostEqualRelative(re, r.getRe()) &&
             almostEqualRelative(qts, r.getQts()) &&
             almostEqualRelative(sd, r.getSd()) &&
-            almostEqualRelative(xmax, r.getXmax()) &&
             almostEqualRelative(z, r.getZ()) &&
-            almostEqualRelative(dia, r.getDia()) &&
-            almostEqualRelative(le, r.getLe()) &&
             almostEqualRelative(qms, r.getQms()) &&
             almostEqualRelative(qes, r.getQes()) &&
-            almostEqualRelative(pe, r.getPe()) &&
-            almostEqualRelative(bl, r.getBL()) &&
             almostEqualRelative(spl, r.getSpl()) &&
+            almostEqualRelative(pe, r.getPe()) &&
+            almostEqualRelative(le, r.getLe()) &&
+            almostEqualRelative(xmax, r.getXmax()) &&
+            almostEqualRelative(bl, r.getBL()) &&
+            almostEqualRelative(dia, r.getDia()) &&
             vc == r.getVc();
 }
 

--- a/speaker.h
+++ b/speaker.h
@@ -68,21 +68,26 @@ private:
     QString vendor;
     QString model;
 
-    double fs; // Hz
-    double vas; // L
-    double re; // Ohm
-    double qts; // unitless
-    double sd; // m² (emissive surface)
-    double xmax; // mm
-    double z; // Ohm
-    double le; // mH
-    double qms; // unitless
-    double qes; // unitless
-    double spl; // dB (sensitivity)
-    double pe; // W (maxpower in normal use)
+    // TSPs
+    double fs; // Hz (resonance frequency)
+    double vas; // L (equivalent volume of air)
+    double re; // Ohm (DC resistance)
+    double qts; // unitless (total Q)
+    double sd; // m² (effective piston area)
+    double z; // Ohm (nominal impedance)
+    double qms; // unitless (mechanical Q)
+    double qes; // unitless (electrical Q)
+    double spl; // dB (sensitivity at 1W power input, in 1m distance)
+
+    // Voice coil parameters
+    double pe; // W (max power in normal use)
+    double le; // mH (voice coil inductance)
+    double xmax; // mm (linear excursion)
     double bl; // Tm (force factor)
-    double dia; // m (diameter)
     int vc; // number of voice coils
+
+    // Mechanical data
+    double dia; // m (cutout diameter)
 };
 
 Q_DECLARE_METATYPE(Speaker)

--- a/speakerdialog.ui
+++ b/speakerdialog.ui
@@ -105,7 +105,7 @@
      <item row="7" column="0">
       <widget class="QLabel" name="diaLabel">
        <property name="text">
-        <string>Dia (m)</string>
+        <string>Dia cutout (m)</string>
        </property>
       </widget>
      </item>
@@ -268,7 +268,7 @@
      <item row="2" column="0">
       <widget class="QLabel" name="vcLabel">
        <property name="text">
-        <string>Voice Coil</string>
+        <string>Voice Coil (#)</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Just a minor cleanup regarding the usage of the different parameter types, e.g.

* TSPs vs voice coil vs mechanical (and update instance initialisation order accordingly)
* Clarify that Dia is the cutout diameter (not voice coil :smile:  )